### PR TITLE
Make walkthrough test after() async/await

### DIFF
--- a/cs-walkthrough/functions/test.js
+++ b/cs-walkthrough/functions/test.js
@@ -55,9 +55,9 @@ describe("shopping carts", () => {
     auth: aliceAuth
   }).firestore();
 
-  after(() => {
+  after(async () => {
     // Clear data from the emulator
-    firebase.clearFirestoreData({ projectId: TEST_FIREBASE_PROJECT_ID });
+    await firebase.clearFirestoreData({ projectId: TEST_FIREBASE_PROJECT_ID });
   });
 
   it('can be created by the cart owner', async () => {
@@ -86,9 +86,9 @@ describe("shopping carts", async () => {
     });
   });
 
-  after(() => {
+  after(async () => {
     // Clear data from the emulator
-    firebase.clearFirestoreData({ projectId: TEST_FIREBASE_PROJECT_ID });
+    await firebase.clearFirestoreData({ projectId: TEST_FIREBASE_PROJECT_ID });
   });
 
   it("can be read, updated, and deleted by the cart owner", async () => {
@@ -120,9 +120,9 @@ describe("shopping cart items", async () => {
     }
   });
 
-  after(() => {
+  after(async () => {
     // Clear data from the emulator
-    firebase.clearFirestoreData({ projectId: TEST_FIREBASE_PROJECT_ID });
+    await firebase.clearFirestoreData({ projectId: TEST_FIREBASE_PROJECT_ID });
   });
 
   it("can be read by the cart owner", async () => {

--- a/manual-emulator-testing/public/index.html
+++ b/manual-emulator-testing/public/index.html
@@ -23,8 +23,8 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/kognise/water.css@latest/dist/light.min.css">
 
     <!-- Firebase SDKs -->
-    <script src="https://www.gstatic.com/firebasejs/7.17.1/firebase-app.js"></script>
-    <script src="https://www.gstatic.com/firebasejs/7.17.1/firebase-firestore.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/7.22.0/firebase-app.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/7.22.0/firebase-firestore.js"></script>
   </head>
 
   <body>


### PR DESCRIPTION
Add async/await clauses to the test.js file within the firestore walkthrough.

I took this example and extended it to match my project and use case... it ended up running into timing collisions and flaky tests without this  async/await in the after hooks.  Therefore, it made sense to update the source to help the next person.